### PR TITLE
Change syntax to correctly add missing library dbus

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_git.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_git.bbappend
@@ -1,2 +1,2 @@
-PACKAGECONFIG = "libpng eglfs gl gles2 accessibility freetype fontconfig jpeg evdev kms gbm dbus"
+PACKAGECONFIG_append = " dbus"
 PACKAGECONFIG_remove = "x11 xcb xkb xkbcommon-evdev"


### PR DESCRIPTION
Previous syntax (overwrite PACKAGECONFIG with new values instead of simply appending necessary values) led to problems regarding layer priorities.