### PR TITLE
Modify certain fields of notify containers service file template

### DIFF
--- a/recipes-containers/container-sd-notify/files/container-sd-notify.service
+++ b/recipes-containers/container-sd-notify/files/container-sd-notify.service
@@ -8,8 +8,8 @@ Type=notify
 NotifyAccess=all
 WorkingDirectory=/apps/container-sd-notify/
 ExecStart=/usr/bin/runc run container-sd-notify
-ExecStartPost=/bin/sh /usr/fullmetalupdate/scripts/send_feedback.sh
-ExecStopPost=/bin/sh /usr/fullmetalupdate/scripts/send_feedback.sh
+ExecStartPost=/bin/sh /usr/fullmetalupdate/scripts/send_feedback.sh "container-sd-notify"
+ExecStopPost=/bin/sh /usr/fullmetalupdate/scripts/send_feedback.sh "container-sd-notify"
 # After this timeout, systemd will consider the startup as failed and stop the 
 # container, and the container will rollback to its previous version
 TimeoutStartSec=35s


### PR DESCRIPTION
The goal is to fit the modifications of "send_feedback.sh" script done within the scope of the new update process (1 socket per feedback thread, 1 feedback thread per notify container --> please see FullMetalUpdate/fullmetalupdate).